### PR TITLE
Remove CI for PyPI Publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,15 +1,14 @@
 name: PyPI Package
 permissions:
   contents: read
-  pull-requests: write
 
 on:
   push:
     branches:
-      - main  # Triggers the workflow on commits to the `main` branch
+      - main  # Triggers the workflow when changes are pushed to the `main` branch
 
 jobs:
-  build-and-publish:
+  publish:
     runs-on: ubuntu-latest
 
     steps:
@@ -23,46 +22,20 @@ jobs:
         with:
           python-version: "3.10"
 
-      # Cache Python dependencies
-      - name: Cache dependencies
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/pyproject.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-
-      # Install build tools
+      # Install build tool
       - name: Install build tools
         run: |
           python -m pip install --upgrade pip
           pip install setuptools wheel twine
 
-      # Install dependencies from pyproject.toml
-      - name: Install dependencies
-        run: |
-          pip install .
-
-      # Run tests
-      - name: Run tests
-        run: |
-          pytest tests/ --maxfail=1 --disable-warnings -q
-
       # Build the package
       - name: Build package
         run: python -m build
-
-      # Save build artifacts
-      - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: dist
-          path: dist/
 
       # Publish to PyPI
       - name: Publish to PyPI
         env:
           TWINE_USERNAME: __token__
-          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }} 
         run: |
           twine upload dist/*


### PR DESCRIPTION
This pull request includes several changes to the `.github/workflows/publish.yml` file to streamline the workflow for publishing a PyPI package. The most important changes involve renaming the job, removing unnecessary steps, and updating comments for clarity.

Workflow improvements:

* Renamed the job from `build-and-publish` to `publish` for better clarity.
* Removed the step for caching Python dependencies to simplify the workflow.
* Removed the steps for installing dependencies and running tests, focusing the workflow solely on building and publishing the package.
* Removed the step for saving build artifacts, as it is no longer necessary.
* Updated the comment for the `main` branch trigger to clarify that it triggers when changes are pushed.