### PR TITLE
Workflow Token Adjustment

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Run Semantic Release
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
           PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
         run: |
           semantic-release publish

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,9 @@
 name: PyPI
 
 on:
+  push:
+    branches:
+      - main
   release:
     types: [created]
   workflow_dispatch:
@@ -50,7 +53,7 @@ jobs:
 
       - name: Run Semantic Release
         env:
-          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }} # Using PAT with repo scope
           PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
         run: |
           semantic-release publish

--- a/.releaserc.yaml
+++ b/.releaserc.yaml
@@ -1,9 +1,0 @@
-branches:
-  - main
-plugins:
-  - "@semantic-release/commit-analyzer"
-  - "@semantic-release/release-notes-generator"
-  - "@semantic-release/changelog"
-  - "@semantic-release/git"
-  - "@semantic-release/github"
-  - "@semantic-release/pypi"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,11 +57,11 @@ version_variables = [
     "pyproject.toml:tool.poetry.version",
     "CITATION.cff:version"
 ]
-branch = "main"
+branch = "main"                 # Branch to track for triggering the release process
 changelog_file = "CHANGELOG.md"
 build_command = "pip install poetry && poetry build"
-dist_path = "dist/"
-create_pr = true
+dist_path = "dist/"             # Directory where the distribution files will be stored
+create_pr = true                # Option to create a pull request when a new release version is created
 pr_branch_prefix = "release/"
 upload_to_pypi = true
 upload_to_release = true
@@ -72,8 +72,12 @@ commit_message = "chore(release): {version} [skip ci]"
 commit_author = "semantic-release <semantic-release@example.com>"
 
 [tool.semantic_release.plugins]
-commit_analyzer = "@semantic-release/commit-analyzer"
-release_notes_generator = "@semantic-release/release-notes-generator"
+commit_analyzer = "@semantic-release/commit-analyzer"           # Analyzes commit messages to determine version bumps
+release_notes_generator = "@semantic-release/release-notes-generator"  # Generates release notes based on commit messages
+changelog = "@semantic-release/changelog"                       # Handles changelog generation
+git = "@semantic-release/git"                                   # Commits changes (version bump, changelog) back to the repo
+github = "@semantic-release/github"                             # Creates GitHub releases (tags) and adds release notes
+pypi = "@semantic-release/pypi"                                 # Uploads the distribution to PyPI
 
 [tool.semantic_release.commit_analyzer]
 preset = "angular"


### PR DESCRIPTION
This pull request includes several changes to the release and publishing workflow configuration files. The main updates are related to the GitHub Actions workflow for publishing to PyPI and the semantic release configuration.

### Updates to GitHub Actions workflow:

* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7R4-R6): Added `push` event trigger for the `main` branch to the workflow configuration.
* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L53-R56): Updated the environment variable for the GitHub token to use `GH_TOKEN` instead of `GITHUB_TOKEN` for running the Semantic Release job.

### Updates to semantic release configuration:

* [`.releaserc.yaml`](diffhunk://#diff-7c44ab2f659232c7a7dfa2847740c40e531b9f1c04a9d316e715b336323bc9c4L1-L9): Removed the semantic release configuration file, as it is no longer needed.
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L60-R64): Added comments to clarify the purpose of various configuration options, such as `branch`, `dist_path`, and `create_pr`.
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L75-R80): Added comments to explain the role of different plugins in the semantic release process.