### PR TITLE
Add debug flag to semantic-release publish command

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,4 +56,4 @@ jobs:
           GH_TOKEN: ${{ secrets.GH_TOKEN }} # Using PAT with repo scope
           PYPI_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
         run: |
-          semantic-release publish
+          semantic-release --debug publish


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/publish.yml` file. The change enables debug mode for the `semantic-release` command.

* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L59-R59): Modified the `semantic-release` command to include the `--debug` flag for better debugging information during the publish process.