### PR TITLE
Poetry Build Fix

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,7 +44,10 @@ jobs:
           python -m pip install --upgrade pip
           pip install poetry
           poetry install --no-interaction
-          poetry run pip install python-semantic-release # 9.x.x
+
+      - name: Build Package
+        run: |
+          poetry build
       
       - name: Configure Git
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 # Ignore Folder/Extensions:
 **/__pycache__/
 
+# Generated Builds
+dist/
+
 # Logs
 **/*LOG.txt
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,7 +4,7 @@ authors:
   - family-names: "Gross"
     given-names: "Michael"
 title: "Mujoco Toolbox"
-version: "0.3.0"
+version: "0.3.3"
 url: "https://github.com/MGross21/mujoco-toolbox"
 date-released: "2024-10-15"
 license: "MIT"

--- a/mujoco_toolbox/__init__.py
+++ b/mujoco_toolbox/__init__.py
@@ -32,7 +32,7 @@ from .controller import (
 from .utils import _Platform
 from .wrapper import Wrapper
 
-__version__ = "0.3.0"
+__version__ = "0.3.3"
 __author__ = "Michael Gross"
 __github_repo__ = "mujoco-toolbox"
 __license__ = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "mujoco-toolbox"
-version = "0.3.0"
+version = "0.3.3"
 description = "A modern package to handle MuJoCo environments"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
This pull request includes updates to the version number and improvements to the build process for the `mujoco-toolbox` project. The most important changes include updating the version number across multiple files and adding a new build step in the GitHub Actions workflow.

Version updates:

* Bump to `v0.3.3`

Build process improvements:

* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L47-R50): Added a new step to build the package using `poetry`.