### PR TITLE
Fix Docs Darkmode. Clean up various docstrings

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,32 +1,42 @@
-:root {
-  --color-background-primary: #1e1e1e;
-  --color-background-secondary: #2d2d2d;
-  --color-background-hover: #3e3e3e;
-  --color-text-primary: #ffffff;
-  --color-text-secondary: #c0c0c0;
-  --color-link: #4e9a06;
-  --color-link-visited: #bb4b4b;
-}
-
-body,
-.wy-body-for-nav,
-.rst-content,
-.wy-nav-content {
-  background-color: var(--color-background-primary) !important;
+/* Code blocks */
+.highlight,
+.literal-block,
+.rst-content code,
+.rst-content pre,
+.rst-content .viewcode-block {
+  background-color: var(--color-background-hover) !important;
   color: var(--color-text-primary) !important;
 }
 
-.wy-side-nav-search,
-.wy-nav-side {
+/* Function signatures & parameters (autodoc/autosummary) */
+.sig,
+.sig-name,
+.sig-param,
+.sig-return,
+.sig-prename,
+.sig-paren {
+  color: var(--color-text-primary) !important;
+}
+
+/* Inline code */
+.rst-content tt,
+.rst-content code {
+  background: var(--color-background-hover) !important;
+  color: var(--color-text-primary) !important;
+}
+
+/* Tables */
+.rst-content table.docutils,
+.rst-content table.field-list {
   background: var(--color-background-secondary) !important;
+  color: var(--color-text-primary) !important;
 }
 
-a,
-.rst-content a {
-  color: var(--color-link) !important;
-}
-
-a:visited,
-.rst-content a:visited {
-  color: var(--color-link-visited) !important;
+/* Headings */
+.rst-content h1,
+.rst-content h2,
+.rst-content h3,
+.rst-content h4,
+.rst-content h5 {
+  color: var(--color-text-primary) !important;
 }

--- a/examples/box_and_leg.ipynb
+++ b/examples/box_and_leg.ipynb
@@ -10,8 +10,7 @@
     "\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
-    "import mujoco_toolbox as mjtb\n",
-    "from mujoco_toolbox.wrapper import mjData  # Type hints"
+    "import mujoco_toolbox as mjtb"
    ]
   },
   {
@@ -47,11 +46,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "def leg_controller(_, data:mjData) -> None:\n",
+    "def leg_controller(_, data) -> None:\n",
     "    \"\"\"Simple leg controller for the MuJoCo model.\"\"\"\n",
     "    # Current state\n",
     "    w = data.qvel[1]  # Current velocity of joint 1\n",

--- a/mujoco_toolbox/__init__.py
+++ b/mujoco_toolbox/__init__.py
@@ -83,7 +83,6 @@ For possible types, see
 
 Capture All:
 ------
-To capture all fields:
 >>> from mujoco_toolbox import mjtb
 >>> mjtb.CAPTURE_PARAMETERS = {"all"}
 

--- a/mujoco_toolbox/builder.py
+++ b/mujoco_toolbox/builder.py
@@ -26,6 +26,17 @@ class Builder:
 
     @staticmethod
     def merge(inputs: Sequence[Union[str, "Builder"]], meshdir: str = "meshes/") -> "Builder":
+        """
+        Merge multiple Builder objects and/or XML strings into one Builder.
+
+        Args:
+            inputs: Sequence of Builder objects and/or XML strings or file paths.
+            meshdir: Mesh directory (default: "meshes/").
+        Returns:
+            Merged Builder instance.
+        Raises:
+            ValueError: If no inputs are provided.
+        """
         if not inputs:
             msg = "No inputs provided for merging."
             raise ValueError(msg)


### PR DESCRIPTION
This pull request includes updates to improve documentation, enhance code readability, and simplify the codebase. Key changes include a major overhaul of the custom CSS for documentation, updates to a Jupyter Notebook example, and improvements to the `Builder` class in the `mujoco_toolbox` library.

### Documentation and Styling Updates:
* [`docs/_static/custom.css`](diffhunk://#diff-2ed9e487689006f9987e65a4e62763cb6580f6197ddb9e4c752e20850e8880d9L1-R41): Replaced the old color scheme with targeted styling for specific elements like code blocks, tables, and headings. This improves readability and provides a more consistent appearance for the documentation.

### Code Simplifications and Type Hint Adjustments:
* [`examples/box_and_leg.ipynb`](diffhunk://#diff-4ddf098798410cdcc6fdbb98777aa3d060482a49d32b1f603c3003b6082a4320L13-R13): Removed the unused `mjData` type hint import and replaced the type hint for the `data` parameter in the `leg_controller` function with a generic type to simplify the code. Also reset the execution count in the notebook. [[1]](diffhunk://#diff-4ddf098798410cdcc6fdbb98777aa3d060482a49d32b1f603c3003b6082a4320L13-R13) [[2]](diffhunk://#diff-4ddf098798410cdcc6fdbb98777aa3d060482a49d32b1f603c3003b6082a4320L50-R53)

### Minor Fixes:
* [`mujoco_toolbox/__init__.py`](diffhunk://#diff-8fba2c9d0ca15d5ca1358928c954c4913316931a22059405f7ace18defe1181fL86): Removed an outdated example in the "Capture All" section of the documentation.

### Improved Documentation for `Builder` Class:
* [`mujoco_toolbox/builder.py`](diffhunk://#diff-8d03b76b73e9d3b9b606a611cca1c6468b2f89533b75b6db909f5344874fea51R29-R39): Added a detailed docstring for the `merge` method in the `Builder` class, clarifying its purpose, arguments, return value, and possible exceptions.