### PR TITLE
Doc build

### DIFF
--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,32 +1,42 @@
-:root {
-  --color-background-primary: #1e1e1e;
-  --color-background-secondary: #2d2d2d;
-  --color-background-hover: #3e3e3e;
-  --color-text-primary: #ffffff;
-  --color-text-secondary: #c0c0c0;
-  --color-link: #4e9a06;
-  --color-link-visited: #bb4b4b;
-}
-
-body,
-.wy-body-for-nav,
-.rst-content,
-.wy-nav-content {
-  background-color: var(--color-background-primary) !important;
+/* Code blocks */
+.highlight,
+.literal-block,
+.rst-content code,
+.rst-content pre,
+.rst-content .viewcode-block {
+  background-color: var(--color-background-hover) !important;
   color: var(--color-text-primary) !important;
 }
 
-.wy-side-nav-search,
-.wy-nav-side {
+/* Function signatures & parameters (autodoc/autosummary) */
+.sig,
+.sig-name,
+.sig-param,
+.sig-return,
+.sig-prename,
+.sig-paren {
+  color: var(--color-text-primary) !important;
+}
+
+/* Inline code */
+.rst-content tt,
+.rst-content code {
+  background: var(--color-background-hover) !important;
+  color: var(--color-text-primary) !important;
+}
+
+/* Tables */
+.rst-content table.docutils,
+.rst-content table.field-list {
   background: var(--color-background-secondary) !important;
+  color: var(--color-text-primary) !important;
 }
 
-a,
-.rst-content a {
-  color: var(--color-link) !important;
-}
-
-a:visited,
-.rst-content a:visited {
-  color: var(--color-link-visited) !important;
+/* Headings */
+.rst-content h1,
+.rst-content h2,
+.rst-content h3,
+.rst-content h4,
+.rst-content h5 {
+  color: var(--color-text-primary) !important;
 }

--- a/docs/_static/custom.css
+++ b/docs/_static/custom.css
@@ -1,20 +1,44 @@
-/* Code blocks */
-.highlight,
-.literal-block,
-.rst-content code,
-.rst-content pre,
-.rst-content .viewcode-block {
-  background-color: var(--color-background-hover) !important;
+:root {
+  --color-background-primary: #1e1e1e;
+  --color-background-secondary: #2d2d2d;
+  --color-background-hover: #3e3e3e;
+  --color-text-primary: #ffffff;
+  --color-text-secondary: #c0c0c0;
+  --color-link: #4e9a06;
+  --color-link-visited: #bb4b4b;
+}
+
+body,
+.wy-body-for-nav,
+.rst-content,
+.wy-nav-content {
+  background-color: var(--color-background-primary) !important;
   color: var(--color-text-primary) !important;
 }
 
-/* Function signatures & parameters (autodoc/autosummary) */
-.sig,
-.sig-name,
-.sig-param,
-.sig-return,
-.sig-prename,
-.sig-paren {
+/* Sidebar and search */
+.wy-side-nav-search,
+.wy-nav-side {
+  background: var(--color-background-secondary) !important;
+}
+
+/* Links */
+a,
+.rst-content a {
+  color: var(--color-link) !important;
+}
+
+a:visited,
+.rst-content a:visited {
+  color: var(--color-link-visited) !important;
+}
+
+/* Code blocks */
+.highlight,
+.literal-block,
+.rst-content pre,
+.rst-content .viewcode-block {
+  background-color: var(--color-background-hover) !important;
   color: var(--color-text-primary) !important;
 }
 
@@ -25,11 +49,27 @@
   color: var(--color-text-primary) !important;
 }
 
+/* Autodoc/autosummary function signatures */
+.sig,
+.sig-name,
+.sig-param,
+.sig-return,
+.sig-prename,
+.sig-paren {
+  color: var(--color-text-primary) !important;
+}
+
 /* Tables */
 .rst-content table.docutils,
 .rst-content table.field-list {
   background: var(--color-background-secondary) !important;
   color: var(--color-text-primary) !important;
+  border-color: var(--color-background-hover) !important;
+}
+
+.rst-content th,
+.rst-content td {
+  border-color: var(--color-background-hover) !important;
 }
 
 /* Headings */
@@ -39,4 +79,11 @@
 .rst-content h4,
 .rst-content h5 {
   color: var(--color-text-primary) !important;
+}
+
+/* Admonitions (notes, warnings, etc.) */
+.rst-content .admonition {
+  background-color: var(--color-background-secondary) !important;
+  color: var(--color-text-primary) !important;
+  border-left: 4px solid var(--color-link) !important;
 }

--- a/examples/box_and_leg.ipynb
+++ b/examples/box_and_leg.ipynb
@@ -10,8 +10,7 @@
     "\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
-    "import mujoco_toolbox as mjtb\n",
-    "from mujoco_toolbox.wrapper import mjData  # Type hints"
+    "import mujoco_toolbox as mjtb"
    ]
   },
   {
@@ -47,11 +46,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "def leg_controller(_, data:mjData) -> None:\n",
+    "def leg_controller(_, data) -> None:\n",
     "    \"\"\"Simple leg controller for the MuJoCo model.\"\"\"\n",
     "    # Current state\n",
     "    w = data.qvel[1]  # Current velocity of joint 1\n",

--- a/mujoco_toolbox/__init__.py
+++ b/mujoco_toolbox/__init__.py
@@ -83,7 +83,6 @@ For possible types, see
 
 Capture All:
 ------
-To capture all fields:
 >>> from mujoco_toolbox import mjtb
 >>> mjtb.CAPTURE_PARAMETERS = {"all"}
 

--- a/mujoco_toolbox/builder.py
+++ b/mujoco_toolbox/builder.py
@@ -26,6 +26,17 @@ class Builder:
 
     @staticmethod
     def merge(inputs: Sequence[Union[str, "Builder"]], meshdir: str = "meshes/") -> "Builder":
+        """
+        Merge multiple Builder objects and/or XML strings into one Builder.
+
+        Args:
+            inputs: Sequence of Builder objects and/or XML strings or file paths.
+            meshdir: Mesh directory (default: "meshes/").
+        Returns:
+            Merged Builder instance.
+        Raises:
+            ValueError: If no inputs are provided.
+        """
         if not inputs:
             msg = "No inputs provided for merging."
             raise ValueError(msg)

--- a/mujoco_toolbox/builder.py
+++ b/mujoco_toolbox/builder.py
@@ -26,16 +26,18 @@ class Builder:
 
     @staticmethod
     def merge(inputs: Sequence[Union[str, "Builder"]], meshdir: str = "meshes/") -> "Builder":
-        """
-        Merge multiple Builder objects and/or XML strings into one Builder.
+        """Merge multiple Builder objects and/or XML strings into one Builder.
 
         Args:
             inputs: Sequence of Builder objects and/or XML strings or file paths.
             meshdir: Mesh directory (default: "meshes/").
+
         Returns:
             Merged Builder instance.
+
         Raises:
             ValueError: If no inputs are provided.
+
         """
         if not inputs:
             msg = "No inputs provided for merging."


### PR DESCRIPTION
This pull request includes updates to improve the styling of documentation, simplify examples, and enhance code documentation. Below is a summary of the most important changes:

### Documentation Styling Updates
* Added custom styles to `docs/_static/custom.css` for various elements, including sidebars, links, code blocks, tables, headings, and admonitions. These changes ensure consistent theming using CSS variables like `--color-text-primary` and `--color-background-secondary`. [[1]](diffhunk://#diff-2ed9e487689006f9987e65a4e62763cb6580f6197ddb9e4c752e20850e8880d9R19-R25) [[2]](diffhunk://#diff-2ed9e487689006f9987e65a4e62763cb6580f6197ddb9e4c752e20850e8880d9R35-R89)

### Simplification of Examples
* Removed type hints for `mjData` in the `leg_controller` function and set the execution count to `null` in the `examples/box_and_leg.ipynb` notebook. This simplifies the example code and makes it more beginner-friendly. [[1]](diffhunk://#diff-4ddf098798410cdcc6fdbb98777aa3d060482a49d32b1f603c3003b6082a4320L13-R13) [[2]](diffhunk://#diff-4ddf098798410cdcc6fdbb98777aa3d060482a49d32b1f603c3003b6082a4320L50-R53)

### Code Documentation Enhancements
* Added detailed docstrings to the `merge` method in `mujoco_toolbox/builder.py`, explaining its purpose, arguments, return value, and potential exceptions. This improves code readability and usability for developers.

### Minor Cleanup
* Removed an outdated example section in `mujoco_toolbox/__init__.py` related to capturing all fields, as it was no longer relevant.