### PR TITLE
GLFW Wayland Warning Suppression

### DIFF
--- a/mujoco_toolbox/__init__.py
+++ b/mujoco_toolbox/__init__.py
@@ -37,8 +37,10 @@ Please refer to the documentation for the most up-to-date information.
 import os
 
 if "WAYLAND_DISPLAY" in os.environ:
-    # Suppress GLFWError window position warnings. Caused by Linux Wayland Auto-tiling Window Manager
-    # Warning Source: https://github.com/glfw/glfw/blob/master/src/wl_window.c#L2246-L2253
+    # Suppress GLFWError window position warnings
+    # Caused by Linux Wayland Auto-tiling Window Manager
+    # Warning Source:
+    # https://github.com/glfw/glfw/blob/master/src/wl_window.c#L2246-L2253
     # Reduces stdout clutter when using MuJoCo with Wayland
     from warnings import filterwarnings
     filterwarnings(

--- a/mujoco_toolbox/__init__.py
+++ b/mujoco_toolbox/__init__.py
@@ -37,12 +37,16 @@ Please refer to the documentation for the most up-to-date information.
 import os
 
 if "WAYLAND_DISPLAY" in os.environ:
-    # os.environ["QT_QPA_PLATFORM"] = "xcb" # Force Qt to use X11 backend
-
-    # Suppress GLFWError warnings
+    # Suppress GLFWError window position warnings. Caused by Linux Wayland Auto-tiling Window Manager
+    # Warning Source: https://github.com/glfw/glfw/blob/master/src/wl_window.c#L2246-L2253
+    # Reduces stdout clutter when using MuJoCo with Wayland
     from warnings import filterwarnings
-    filterwarnings("ignore", category=UserWarning, module="glfw")
-
+    filterwarnings(
+        "ignore",
+        category=UserWarning,
+        module="glfw",
+        message=".*window position.*",
+    )
     try:
         from ctypes import CDLL
         CDLL("libfontconfig.so.1").FcInit()

--- a/mujoco_toolbox/__init__.py
+++ b/mujoco_toolbox/__init__.py
@@ -37,14 +37,17 @@ Please refer to the documentation for the most up-to-date information.
 import os
 
 if "WAYLAND_DISPLAY" in os.environ:
-    os.environ["MUJOCO_GL"] = "egl"
-    os.environ["QT_QPA_PLATFORM"] = "wayland"
-    os.environ["SDL_VIDEODRIVER"] = "wayland"
-    os.environ["PYGLFW_LIBRARY_VARIANT"] = "wayland"
+    os.environ["QT_QPA_PLATFORM"] = "xcb" # Force Qt to use X11 backend
 
     # Suppress GLFWError warnings
     from warnings import filterwarnings
     filterwarnings("ignore", category=UserWarning, module="glfw")
+
+    try:
+        from ctypes import CDLL
+        CDLL("libfontconfig.so.1").FcInit()
+    except Exception:
+        pass
 
 from .assets import WORLD_ASSETS, glovebox
 from .builder import Builder

--- a/mujoco_toolbox/__init__.py
+++ b/mujoco_toolbox/__init__.py
@@ -37,8 +37,7 @@ Please refer to the documentation for the most up-to-date information.
 import os
 
 if "WAYLAND_DISPLAY" in os.environ:
-    # Suppress GLFWError window position warnings
-    # Caused by Linux Wayland Auto-tiling Window Manager
+    # Suppress GLFWError window position warnings caused by Wayland.
     # Warning Source:
     # https://github.com/glfw/glfw/blob/master/src/wl_window.c#L2246-L2253
     # Reduces stdout clutter when using MuJoCo with Wayland

--- a/mujoco_toolbox/__init__.py
+++ b/mujoco_toolbox/__init__.py
@@ -34,6 +34,18 @@ Please refer to the documentation for the most up-to-date information.
 
 """  # noqa: D205, D400, D415, W291
 
+import os
+
+if "WAYLAND_DISPLAY" in os.environ:
+    os.environ["MUJOCO_GL"] = "egl"
+    os.environ["QT_QPA_PLATFORM"] = "wayland"
+    os.environ["SDL_VIDEODRIVER"] = "wayland"
+    os.environ["PYGLFW_LIBRARY_VARIANT"] = "wayland"
+
+    # Suppress GLFWError warnings
+    from warnings import filterwarnings
+    filterwarnings("ignore", category=UserWarning, module="glfw")
+
 from .assets import WORLD_ASSETS, glovebox
 from .builder import Builder
 from .controllers import (

--- a/mujoco_toolbox/__init__.py
+++ b/mujoco_toolbox/__init__.py
@@ -37,7 +37,7 @@ Please refer to the documentation for the most up-to-date information.
 import os
 
 if "WAYLAND_DISPLAY" in os.environ:
-    os.environ["QT_QPA_PLATFORM"] = "xcb" # Force Qt to use X11 backend
+    # os.environ["QT_QPA_PLATFORM"] = "xcb" # Force Qt to use X11 backend
 
     # Suppress GLFWError warnings
     from warnings import filterwarnings


### PR DESCRIPTION
This pull request introduces a change to suppress unnecessary warnings when using MuJoCo with Wayland, improving the user experience by reducing stdout clutter.

### Warning suppression for Wayland environments:
* [`mujoco_toolbox/__init__.py`](diffhunk://#diff-8fba2c9d0ca15d5ca1358928c954c4913316931a22059405f7ace18defe1181fR37-R56): Added logic to suppress GLFWError window position warnings caused by Wayland by filtering relevant warnings and initializing font configuration using `libfontconfig`. This change reduces stdout clutter when running MuJoCo on Wayland systems.

Closes #65